### PR TITLE
Added XML export for automation purposes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     # run only against tags
+    branches:
+      - main
     tags:
       - "*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
   push:
     # run only against tags
-    branches:
-      - master
     tags:
       - "*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   push:
     # run only against tags
     branches:
-      - main
+      - master
     tags:
       - "*"
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Filters schedule by room/location
 - Supports import into Google Calendar, Apple Calendar, Outlook, and more
 - Compatible with Dakboard and other digital signage solutions (per-room schedules)
+- Functionality to have just a plain XML (presenter/subject) output at /location/{id}/xml for use with external programs.
 
 ## 🛠️ Installation
 

--- a/main.go
+++ b/main.go
@@ -122,11 +122,7 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 
 	type Schedule struct {
 		Events []Event `xml:"event"`
-	}
-
-	type scheduleWrapper struct {
-		Schedule Schedule `xml:"schedule"`
-	}
+	} `xml:"schedule"`
 
 	var result Schedule
 	
@@ -140,7 +136,7 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	output, err := xml.MarshalIndent(scheduleWrapper{Schedule: result}, "", "  ")
+	output, err := xml.MarshalIndent(result, "", "  ")
 	if err != nil {
 		http.Error(w, "Failed to generate XML: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/main.go
+++ b/main.go
@@ -122,10 +122,14 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 
 	type Schedule struct {
 		Events []Event `xml:"event"`
-	} `xml:"schedule"`
+	}
+
+	type wrappedSchedule struct {
+		Schedule `xml:"schedule"`
+	}
 
 	var result Schedule
-
+	
 	for _, ev := range cal.Events() {
 		summary := ev.GetProperty(ics.ComponentPropertySummary).Value
 		parts := strings.Split(summary, " - ")

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 
 	type Schedule struct {
 		Events []Event `xml:"event"`
-	}
+	} `xml:"schedule"`
 
 	var result Schedule
 
@@ -130,8 +130,8 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 		summary := ev.GetProperty(ics.ComponentPropertySummary).Value
 		parts := strings.Split(summary, " - ")
 		if len(parts) >= 2 {
-			title := strings.Join(parts[:len(parts)-1], " - ")
-			presenters := parts[len(parts)-1]
+			title := strings.ReplaceAll(strings.Join(parts[:len(parts)-1], " - "), `\,`, `,`)
+			presenters := strings.ReplaceAll(parts[len(parts)-1], `\,`, `,`)
 			result.Events = append(result.Events, Event{Title: title, Presenter: presenters})
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 	} `xml:"schedule"`
 
 	var result Schedule
-	
+
 	for _, ev := range cal.Events() {
 		summary := ev.GetProperty(ics.ComponentPropertySummary).Value
 		parts := strings.Split(summary, " - ")

--- a/main.go
+++ b/main.go
@@ -124,8 +124,8 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 		Events []Event `xml:"event"`
 	}
 
-	type wrappedSchedule struct {
-		Schedule `xml:"schedule"`
+	type scheduleWrapper struct {
+		Schedule Schedule `xml:"schedule"`
 	}
 
 	var result Schedule
@@ -140,7 +140,7 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	output, err := xml.MarshalIndent(wrappedSchedule{Schedule: result}, "", "  ")
+	output, err := xml.MarshalIndent(scheduleWrapper{Schedule: result}, "", "  ")
 	if err != nil {
 		http.Error(w, "Failed to generate XML: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	output, err := xml.MarshalIndent(result, "", "  ")
+	output, err := xml.MarshalIndent(wrappedSchedule{Schedule: result}, "", "  ")
 	if err != nil {
 		http.Error(w, "Failed to generate XML: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/main.go
+++ b/main.go
@@ -122,9 +122,14 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 
 	type Schedule struct {
 		Events []Event `xml:"event"`
-	} `xml:"schedule"`
+	}
 
-	var result Schedule
+	type XMLSchedule struct {
+		XMLName  xml.Name `xml:"schedule"`
+		Events []Event `xml:"event"`
+	}
+
+	var result []Event
 
 	for _, ev := range cal.Events() {
 		summary := ev.GetProperty(ics.ComponentPropertySummary).Value
@@ -132,11 +137,15 @@ func returnSingleLocationXML(w http.ResponseWriter, r *http.Request) {
 		if len(parts) >= 2 {
 			title := strings.ReplaceAll(strings.Join(parts[:len(parts)-1], " - "), `\,`, `,`)
 			presenters := strings.ReplaceAll(parts[len(parts)-1], `\,`, `,`)
-			result.Events = append(result.Events, Event{Title: title, Presenter: presenters})
+			result = append(result, Event{Title: title, Presenter: presenters})
 		}
 	}
 
-	output, err := xml.MarshalIndent(result, "", "  ")
+	outputStruct := XMLSchedule{
+		Events: result,
+	}
+
+	output, err := xml.MarshalIndent(outputStruct, "", "  ")
 	if err != nil {
 		http.Error(w, "Failed to generate XML: "+err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
In the current program no XML export was available. I have added the /location/{id}/xml router and function needed to export an XML output which can be used for automation purposes.

The output will be formatted like this:

```
<schedule>
  <event>
    <title>Talk Title</title>
    <presenter>John Doe</presenter>
  </event>
  <event>
    <title>Workshop</title>
    <presenter>Jane Smith</presenter>
  </event>
</schedule>
```

So any automation can use the XPath ```/schedule/event```